### PR TITLE
Added text selection to auto add to translations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "cSpell.words": [
+        "fontello"
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "i18n-l10n-editor"  and "i18n-arb-editor" extension will be documented in this file.
 
+## [3.0.10]
+
+- Added the ability to select text (must include quotes) in .dart file to add to translations
+  - You will need to open the i18n/l10n Editor first and then click on the tab after you add the text
+  - Use the context globe to select 'Add text to i18n/l10n Editor'
+  - It will auto translate of enabled and follows the case style setting
+  
 ## [3.0.8]
 
 - Added new setting i18n-l10n-editor.keyCaseStyle, this will replace i18n-l10n-editor.forceKeyUPPERCASE

--- a/README.md
+++ b/README.md
@@ -1,55 +1,54 @@
 # i18n-l10n-editor
 
-![logo](https://vanderseypen.dev/assets/images/i18n/logo-large.png)
+<img src="media/logo-large.png" title="Logo"/>
 
-i18n-l10n-editor is a Visual Studio Code extension to easily edit your json translations files.
-<br>
+i18n-l10n-editor is a Visual Studio Code extension to easily edit your i18n and l10n translations files.
 
 ## Usage
 
 i18n-l10n-editor can be used in two ways :
 
--   Right click on a folder named **i18n** and select : **i18n JSON Editor** <br>
+- Click the **i18n/l10n Button on the status bar. This will search for any l10n.yaml file and then open the translations from these files.
+
+- Right click on a folder named **i18n** or **l10n** and select : **i18n/l10n Editor** <br>
     _Folder name can be changed with <ins>i18n-l10n-editor.supportedFolders</ins>_<br><br> ![extension demo](media/demo.gif)
 
-<br><br>
-
--   Within a workspace you can edit several folders at the same time. Click on **i18n editor** presents in the Status Bar <br>
+- Within a workspace you can edit several folders at the same time. Click on **i18n/l10n editor** presents in the Status Bar <br>
     _<ins>i18n-l10n-editor.workspaceFolders</ins> must be set_<br><br> ![status bar extension](https://vanderseypen.dev/assets/images/i18n/workspace.png)
 
 <br><br>
 
--   To use a translation service defined : <br>
+- To use a translation service defined : <br>
     _<ins>i18n-l10n-editor.translationService</ins> and <ins>i18n-l10n-editor.translationServiceApiKey</ins>_<br><br> ![extension demo translate](media/demo-translate.gif)
 
 ## Configuration
 
--   **i18n-l10n-editor.forceKeyUPPERCASE** : Force the keys to uppercase (default : true)
+- **i18n-l10n-editor.forceKeyUPPERCASE** : Force the keys to uppercase (default : true)
 
 ```json
   "i18n-l10n-editor.forceKeyUPPERCASE": false
 ```
 
--   **i18n-l10n-editor.jsonSpace** : A String or Number that's used to insert white space into the output JSON (default : 2) <br>
+- **i18n-l10n-editor.jsonSpace** : A String or Number that's used to insert white space into the output JSON (default : 2) <br>
     _For more information, have a look on the JSON.stringify() method._
 
 ```json
   "i18n-l10n-editor.jsonSpace": 5
 ```
 
--   **i18n-l10n-editor.lineEnding** : String used to signify the end of a line (default : "\n")
+- **i18n-l10n-editor.lineEnding** : String used to signify the end of a line (default : "\n")
 
 ```json
   "i18n-l10n-editor.lineEnding": "\r\n"
 ```
 
--   **i18n-l10n-editor.keySeparator** : String to separate keys, or false if no separator is preferred (default : ".")
+- **i18n-l10n-editor.keySeparator** : String to separate keys, or false if no separator is preferred (default : ".")
 
 ```json
     "i18n-l10n-editor.keySeparator": "/"
 ```
 
--   **i18n-l10n-editor.supportedFolders** : An array of folder names that's used to open the extension through the right click (default : ["i18n"]) <br> _<ins>Restart Visual Studio Code</ins> after changing the value_
+- **i18n-l10n-editor.supportedFolders** : An array of folder names that's used to open the extension through the right click (default : ["i18n"]) <br> _<ins>Restart Visual Studio Code</ins> after changing the value_
 
 ```json
     "i18n-l10n-editor.supportedFolders": [
@@ -58,19 +57,19 @@ i18n-l10n-editor can be used in two ways :
     ]
 ```
 
--   **i18n-l10n-editor.translationService** : Specified wich translation service to use (Only Microsoft translator is currently available)
+- **i18n-l10n-editor.translationService** : Specified wich translation service to use (Only Microsoft translator is currently available)
 
 ```json
   "i18n-l10n-editor.translationService" : "MicrosoftTranslator"
 ```
 
--   **i18n-l10n-editor.translationServiceApiKey** : Api key used by the translation service
+- **i18n-l10n-editor.translationServiceApiKey** : Api key used by the translation service
 
 ```json
   "i18n-l10n-editor.translationServiceApiKey": "**********"
 ```
 
--   **i18n-l10n-editor.workspaceFolders** : An array of objects to specify which folders are used to manage your translations
+- **i18n-l10n-editor.workspaceFolders** : An array of objects to specify which folders are used to manage your translations
 
 ```json
   "i18n-l10n-editor.workspaceFolders": [

--- a/media/template.html
+++ b/media/template.html
@@ -23,12 +23,14 @@
           >
           </select>
           <input
+            id="search-text"
             class="form-control"
             oninput="search(this)"
             style="width: 350px;"
             type="text"
             placeholder="Search..."
             aria-label="Search..."
+            value=""
           />
         </form>
         <form class="form-inline" style="padding-top: 0px; position: fixed; right: 20px; z-index: 1100; float: right;">

--- a/media/template.js
+++ b/media/template.js
@@ -32,7 +32,16 @@ var vscode;
 
         break;
 
-      case "update":
+        case "search-text":
+          const search = message.search;
+          if (search) {
+            var select = document.getElementById("search-text");
+
+            select.value = search;
+          }
+  
+          break;
+        case "update":
         const t = message.translation;
         if (t) {
           const el = document.getElementById(`input-key-${t.id}`);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "description": "Easily edit your i18n/l10n json files",
     "icon": "media/logo.png",
-    "version": "3.0.8",
+    "version": "3.0.10",
     "engines": {
         "vscode": "^1.80.0"
     },
@@ -50,9 +50,9 @@
                     "description": "Force the keys to uppercase (deprecated)."
                 },
                 "i18n-l10n-editor.keyCaseStyle": {
-                    "default": "camelCase",
+                    "default": "no change",
                     "type": "string",
-                    "enum":  ["no change", "camelCase", "lowercase", "UPPERCASE"],
+                    "enum":  ["no change", "camelCase", "Capalize", "lowercase", "UPPERCASE"],
                     "description": "how to write keys to the files valid methods are [no change, camelCase, lowercase, UPPERCASE].\ncamelCase requires spaces when typing key."
                 },
                 "i18n-l10n-editor.sortKeyTogether": {

--- a/src/i18n-l10n-editor/applySaveAndRunFlutterPubGet.ts
+++ b/src/i18n-l10n-editor/applySaveAndRunFlutterPubGet.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { EditFilesParameters } from './commands/editFilesParameters';
+import { IJEManager } from './ije-manager';
+//import { getChangesForArbFiles } from '../getChangesForArbFiles';
+//import { runFlutterPubGet } from './runFlutterPubGet';
+
+export async function applySaveAndRunFlutterPubGet(editFilesParameters: EditFilesParameters): Promise<void> {
+    const manager: IJEManager = IJEManager.manager;
+    const { workspace } = vscode;
+
+    if (manager) {
+        let file = editFilesParameters.uri.path;
+        if (file.lastIndexOf('/') !== -1) {
+            file = file.substring(file.lastIndexOf('/') + 1);
+            if (editFilesParameters.description !== "") {
+                manager.addKey(`@${editFilesParameters.keyValue.key}.description`, editFilesParameters.description);
+            } else {
+                manager.addKey(`@${editFilesParameters.keyValue.key}.description`, `Added from file ${file}`);
+            }
+        }
+        if (editFilesParameters.placeholders) {
+            let value = editFilesParameters.keyValue.value;
+            editFilesParameters.placeholders.forEach(p => {
+                if (value.toLocaleLowerCase().indexOf("$" + p.name.toLocaleLowerCase()) !== -1) {
+                    value = value.substring(0, value.toLocaleLowerCase().indexOf("$" + p.name.toLocaleLowerCase())) + 
+                    "{" + p.name + "}" +
+                    value.substring(value.toLocaleLowerCase().indexOf("$" + p.name.toLocaleLowerCase()) + ("$" + p.name).length);
+                    //value = value.replace("$" + p.name, "{" + p.name + "}");
+                } else if (value.toLocaleLowerCase().indexOf("${" + p.name.toLocaleLowerCase() + "}") !== -1) {
+                    value = value.substring(0, value.toLocaleLowerCase().indexOf("${" + p.name.toLocaleLowerCase() + 
+                    "}")) + "{" + p.name + "}" +
+                    value.substring(value.toLocaleLowerCase().indexOf("${" + p.name.toLocaleLowerCase() + "}") + ("${" + p.name + "}").length);
+                    //value = value.replace("${" + p.name + "}", "{" + p.name + "}");
+                }
+                manager.addKey(`@${editFilesParameters.keyValue.key}.placeholders.${p.name}.type`, p.type);
+                manager.addKey(`@${editFilesParameters.keyValue.key}.placeholders.${p.name}.example`, p.name);  
+            });
+            manager.addKey(editFilesParameters.keyValue.key, value);
+        } else {
+            manager.addKey(editFilesParameters.keyValue.key, editFilesParameters.keyValue.value);
+        }
+
+        const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+        sleep(250);
+
+        IJEManager.manager.search(editFilesParameters.keyValue.key);
+    }
+}
+

--- a/src/i18n-l10n-editor/commands/commandParameters.ts
+++ b/src/i18n-l10n-editor/commands/commandParameters.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+export class CommandParameters {
+  constructor(
+    readonly uri: vscode.Uri,
+    readonly range: vscode.Range,
+    readonly value: string
+  ) {
+    // do nothing.
+  }
+}

--- a/src/i18n-l10n-editor/commands/editFilesCommand.ts
+++ b/src/i18n-l10n-editor/commands/editFilesCommand.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+import { EditFilesParameters } from './editFilesParameters';
+
+export class EditFilesCommand implements vscode.Command {
+  public static readonly commandName = 'i18n-l10n-editor.editFiles';
+
+  constructor(args: EditFilesParameters[]) {
+    this.title = 'Edit files';
+    this.command = EditFilesCommand.commandName;
+    this.arguments = args;
+  }
+
+  readonly title: string;
+
+  readonly command: string;
+
+  readonly tooltip?: string;
+
+  readonly arguments?: EditFilesParameters[];
+}

--- a/src/i18n-l10n-editor/commands/editFilesParameters.ts
+++ b/src/i18n-l10n-editor/commands/editFilesParameters.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+import { KeyValuePair } from '../shared/keyValuePair';
+import { Placeholder } from '../placeholders/placeholder';
+
+export class EditFilesParameters {
+  constructor(
+    readonly uri: vscode.Uri,
+    readonly range: vscode.Range,
+    readonly keyValue: KeyValuePair,
+    readonly description: string | null,
+    readonly placeholders: Placeholder[]
+  ) {
+    // do nothing.
+  }
+}

--- a/src/i18n-l10n-editor/commands/inputBoxCommand.ts
+++ b/src/i18n-l10n-editor/commands/inputBoxCommand.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+import { CommandParameters } from './commandParameters';
+
+export class InputBoxCommand implements vscode.Command {
+  public static readonly commandName = 'i18n-l10n-editor.inputBox';
+
+  constructor(args: CommandParameters[]) {
+  this.title = 'Add text to i18n/l10n Editor';
+    this.command = InputBoxCommand.commandName;
+    this.arguments = args;
+  }
+
+  readonly title: string;
+
+  readonly command: string;
+
+  readonly tooltip?: string;
+
+  readonly arguments?: CommandParameters[];
+}

--- a/src/i18n-l10n-editor/commands/setEditFilesParameters.ts
+++ b/src/i18n-l10n-editor/commands/setEditFilesParameters.ts
@@ -1,0 +1,108 @@
+/* eslint-disable max-depth */
+/* eslint-disable no-await-in-loop */
+import { LionizationPickItem, showQuickPick } from '../quickPick/showQuickPick';
+import { includeInCustomPattern, includeInDecimalDigits, includeInSymbol, validNumberFormats } from '../placeholders/numberFormat';
+import { CommandParameters } from '../commands/commandParameters';
+import { EditFilesParameters } from '../commands/editFilesParameters';
+import { KeyValuePair } from '../shared/keyValuePair';
+import { Placeholder } from '../placeholders/placeholder';
+import { PlaceholderType } from '../placeholders/placeholderType';
+import { camelize } from '../shared/camelize';
+import { extractInterpolatedVariables } from '../shared/parser/parser';
+import { getConfiguration } from '../getConfiguration';
+import { showDateFormatQuickPick } from '../placeholders/dateFormatQuickPick';
+import { showInputBox } from '../services/inputBox/showInputBox';
+import { showPlaceholderQuickPick } from '../placeholders/placeholderQuickPick';
+import { IJEConfiguration } from '../ije-configuration';
+import { nochange } from '../shared/nochange';
+import { capalize } from '../shared/capalize';
+
+async function getPlaceholder(variable: string) {
+    const name = await showInputBox(`Enter the name of the variable ${variable}`, camelize(variable));
+    const placeholderType = await showPlaceholderQuickPick(name);
+
+    let placeholder = new Placeholder(name, variable, placeholderType);
+
+    switch (placeholderType) {
+        case PlaceholderType.DateTime: {
+            const format = await showDateFormatQuickPick(name);
+            placeholder = placeholder.addFormat(format);
+            break;
+        }
+        case PlaceholderType.int:
+        case PlaceholderType.num:
+        case PlaceholderType.double: {
+            const numberFormats: string[] = [];
+            if (placeholderType === PlaceholderType.int) {
+                numberFormats.push('none');
+            }
+            numberFormats.push(...validNumberFormats);
+            const format = await showQuickPick(
+                `Choose the number format for the variable ${variable}`,
+                numberFormats.map(p => new LionizationPickItem(p))
+            );
+            if (format !== 'none') {
+                placeholder = placeholder.addFormat(format);
+                if (includeInSymbol(format)) {
+                    const symbol = await showInputBox(`Choose the symbol for the variable ${name}`, '');
+                    placeholder = placeholder.addSymbol(symbol);
+                }
+                if (includeInDecimalDigits(format)) {
+                    const decimalDigits = await showInputBox(`Choose the decimal digits for the variable ${name}`, '');
+                    placeholder = placeholder.addDecimalDigits(Number(decimalDigits));
+                }
+                if (includeInCustomPattern(format)) {
+                    const customPattern = await showInputBox(`Choose the custom pattern for the variable ${name}`, '');
+                    placeholder = placeholder.addCustomPattern(customPattern);
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    return placeholder;
+}
+
+export async function setEditFilesParameters(commandParameters: CommandParameters): Promise<EditFilesParameters> {
+    let k = camelize(commandParameters.value);
+    const caseStyle = IJEConfiguration.KEY_CASE_STYLE;
+    if (IJEConfiguration.FORCE_KEY_UPPERCASE || caseStyle === 'UPPERCASE') {
+        k = k.toLocaleUpperCase();
+    } else {
+        switch (caseStyle) {
+            case 'no change':
+                k = nochange(commandParameters.value);
+                break;
+            case 'Capalize':
+                k = capalize(commandParameters.value).replace(/[ ]/g, "");
+                break;
+            case 'lowercase':
+                k = k.toLocaleLowerCase();
+                break;
+        }
+    }
+    const key = await showInputBox('Enter key name', k);
+
+    let description = '';
+
+    let file = commandParameters.uri.path;
+    if (file.lastIndexOf('/') !== -1) {
+        file = file.substring(file.lastIndexOf('/') + 1);
+        description = `Added from file ${file}`;
+    }
+
+    description = await showInputBox('Enter a description for this key', description);
+
+    const variables = extractInterpolatedVariables(commandParameters.value);
+    const placeholders: Placeholder[] = [];
+    if (Array.isArray(variables)) {
+        for (const variable of variables) {
+            placeholders.push(await getPlaceholder(variable));
+        }
+    }
+
+    return new EditFilesParameters(commandParameters.uri, commandParameters.range, new KeyValuePair(key, commandParameters.value), description, placeholders);
+}
+

--- a/src/i18n-l10n-editor/getConfiguration.ts
+++ b/src/i18n-l10n-editor/getConfiguration.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+
+export function getConfiguration(
+  section: string
+): vscode.WorkspaceConfiguration {
+  return vscode.workspace.getConfiguration(section);
+}

--- a/src/i18n-l10n-editor/ije-data.ts
+++ b/src/i18n-l10n-editor/ije-data.ts
@@ -60,6 +60,45 @@ export class IJEData {
         this._manager.refreshDataTable();
     }
 
+    addKey(key: string, text: string) {
+        const folders = IJEConfiguration.WORKSPACE_FOLDERS;
+        folders.forEach(f => {
+            const translation = this._createFactoryIJEDataTranslation();
+            let arb = f.arb;
+            if (arb.lastIndexOf('.') !== -1) {
+                arb = arb.substring(0, arb.lastIndexOf('.'));
+            }
+            translation.key = key;
+            // translation.languages = { [arb]: text };
+            if (key.startsWith('@') && !key.startsWith('@@')) {
+                //const t = this._get(translation.id);
+                this._languages.forEach(l => {
+                    // if (l !== arb) {
+                        translation.languages[l] = text;
+                        
+                    // }
+                });
+                this._insert(translation);
+            } else {
+                let lang: string = '';
+                translation.languages[arb] = text;
+                this._insert(translation);
+                this._languages.forEach(l => {
+                    if (l !== arb) {
+                        lang += `,${l}`;
+                    }
+                });
+                if (lang !== '') {
+                    lang = lang.substring(1);
+                }
+                this.translate(translation.id, arb, lang);
+            }
+
+            //this._view.selectionId = translation.id;
+            this._manager.refreshDataTable();
+        });
+    }
+
     changeFolder(id: number, value: string) {
         const translation = this._get(id);
         translation.folder = value;
@@ -177,8 +216,8 @@ export class IJEData {
 
         const values: string[] = [];
 
-        if (oldLang.lastIndexOf("_") > oldLang.indexOf("_") && oldLang.indexOf("_") !== -1) {
-            oldLang = oldLang.substring(0, oldLang.lastIndexOf("_"));
+        if (oldLang.lastIndexOf('_') > oldLang.indexOf('_') && oldLang.indexOf('_') !== -1) {
+            oldLang = oldLang.substring(0, oldLang.lastIndexOf('_'));
         }
 
         if (lang.length > 0) {
@@ -197,7 +236,7 @@ export class IJEData {
                                     this.translate(translate.id, oldLang, lang);
                                     //const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
                                     //sleep(250);
-                                                        }
+                                }
                             }
                         }
                     }
@@ -225,36 +264,7 @@ export class IJEData {
         }
 
         let existingExtensions = IJEConfiguration.SUPPORTED_EXTENSIONS;
-        /*
-        This code seems to only write {} to a file and can cause issues no idea why it is here.
-        existingFolders.forEach(d => {
-            this._languages.forEach(language => {
-                const json = JSON.stringify({}, null, IJEConfiguration.JSON_SPACE);
-                existingExtensions.forEach((ext: string) => {
-                    var s = vscode.Uri.file(_path.join(d, language + '.' + ext)).fsPath;
-                    if (fs.existsSync(s)) {
-                        f = s;
-                        return;
-                    }
-                });
-                if (f === null) {
-                    f = vscode.Uri.file(_path.join(d, language + '.' + existingExtensions[0])).fsPath;
-                }
-                fs.writeFileSync(f + '.tmp1', json + '\n');
-                const stats = fs.statSync(f + '.tmp1');
-                if (stats.size > 20) {
-                    fs.copyFileSync(f + '.tmp', f);
-                    fs.unlinkSync(f + '.tmp');
-                    vscode.window.showInformationMessage(msg);
-                    saved = true;
-                } else {
-                    vscode.window.showErrorMessage('Error saving translation "' + f + '". Temporary files kept.');
-                    saved = false;
-                }
-            });
-        });
-        */
-        //
+        
         let folders: { [key: string]: IJEDataTranslation[] } = this._translations.reduce((r, a) => {
             r[a.folder] = r[a.folder] || [];
             r[a.folder].push(a);

--- a/src/i18n-l10n-editor/ije-manager.ts
+++ b/src/i18n-l10n-editor/ije-manager.ts
@@ -7,6 +7,9 @@ import { IJEData } from './ije-data';
 import { IJEDataTranslation } from './models/ije-data-translation';
 
 export class IJEManager {
+    static manager: IJEManager;
+    static editor = vscode.window.activeTextEditor;
+
     get isWorkspace() {
         return this.folderPath === null;
     }
@@ -17,6 +20,9 @@ export class IJEManager {
         this._initEvents();
         this._initTemplate();
         _panel.webview.html = this.getTemplate();
+
+        IJEManager.manager = this;
+        IJEManager.editor = vscode.window.activeTextEditor;
     }
 
     _initEvents() {
@@ -77,6 +83,20 @@ export class IJEManager {
     _initTemplate() {
         if (this.isWorkspace) {
             this._panel.webview.postMessage({ command: 'folders', folders: IJEConfiguration.WORKSPACE_FOLDERS });
+        }
+    }
+
+    addKey(key: string, text: string) {
+        this._data.addKey(key, text);
+    }
+
+    search(key: string) {
+        this._panel.webview.postMessage({ command: 'search-text', search: key });
+
+        this._data.search(key);
+        if (IJEManager.editor) {
+            //vscode.workspace.textDocuments;
+            IJEManager.editor.show(IJEManager.editor.viewColumn);
         }
     }
 

--- a/src/i18n-l10n-editor/placeholders/dateFormat.ts
+++ b/src/i18n-l10n-editor/placeholders/dateFormat.ts
@@ -1,0 +1,50 @@
+/**
+ * {@link https://github.com/flutter/flutter/blob/91aeda7bf6f977207d7ac07ca46c26560007a244/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart#L28}
+ */
+export const validDateFormats = [
+  'd',
+  'E',
+  'EEEE',
+  'LLL',
+  'LLLL',
+  'M',
+  'Md',
+  'MEd',
+  'MMM',
+  'MMMd',
+  'MMMEd',
+  'MMMM',
+  'MMMMd',
+  'MMMMEEEEd',
+  'QQQ',
+  'QQQQ',
+  'y',
+  'yM',
+  'yMd',
+  'yMEd',
+  'yMMM',
+  'yMMMd',
+  'yMMMEd',
+  'yMMMM',
+  'yMMMMd',
+  'yMMMMEEEEd',
+  'yQQQ',
+  'yQQQQ',
+  'H',
+  'Hm',
+  'Hms',
+  'j',
+  'jm',
+  'jms',
+  'jmv',
+  'jmz',
+  'jv',
+  'jz',
+  'm',
+  'ms',
+  's'
+];
+
+export function notInclude(value: string) {
+  return !validDateFormats.includes(value);
+}

--- a/src/i18n-l10n-editor/placeholders/dateFormatQuickPick.ts
+++ b/src/i18n-l10n-editor/placeholders/dateFormatQuickPick.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+import { notInclude, validDateFormats } from './dateFormat';
+import { LionizationPickItem } from '../quickPick/showQuickPick';
+
+export async function showDateFormatQuickPick(
+  variable: string
+): Promise<string> {
+  const disposables: vscode.Disposable[] = [];
+  try {
+    return await new Promise<string>((resolve) => {
+      const quickPick = vscode.window.createQuickPick();
+      quickPick.title = `Choose the number format for the variable ${variable}`;
+      quickPick.items = validDateFormats.map((s) => new LionizationPickItem(s));
+      quickPick.onDidChangeValue(() => {
+        if (notInclude(quickPick.value))
+          quickPick.items = [quickPick.value, ...validDateFormats].map(
+            (label) => ({
+              label
+            })
+          );
+      });
+      disposables.push(
+        quickPick.onDidChangeSelection((selected) => {
+          quickPick.enabled = false;
+          quickPick.busy = true;
+          const item = selected[0];
+          resolve(item.label);
+          quickPick.enabled = true;
+          quickPick.busy = false;
+          quickPick.hide();
+        })
+      );
+      quickPick.show();
+    });
+  } finally {
+    disposables.forEach((d) => {
+      d.dispose();
+    });
+  }
+}

--- a/src/i18n-l10n-editor/placeholders/numberFormat.ts
+++ b/src/i18n-l10n-editor/placeholders/numberFormat.ts
@@ -1,0 +1,36 @@
+export const validNumberFormats = [
+  'compact',
+  'compactCurrency',
+  'compactSimpleCurrency',
+  'compactLong',
+  'currency',
+  'decimalPattern',
+  'decimalPercentPattern',
+  'percentPattern',
+  'scientificPattern',
+  'simpleCurrency'
+];
+
+export const numberFormatsWithSymbol = ['compactCurrency', 'currency'];
+
+export function includeInSymbol(value: string) {
+  return numberFormatsWithSymbol.includes(value);
+}
+
+export const numberFormatsWithDecimalDigits = [
+  'compactCurrency',
+  'compactSimpleCurrency',
+  'currency',
+  'decimalPercentPattern',
+  'simpleCurrency'
+];
+
+export function includeInDecimalDigits(value: string) {
+  return numberFormatsWithDecimalDigits.includes(value);
+}
+
+export const numberFormatsWithCustomPattern = ['currency'];
+
+export function includeInCustomPattern(value: string) {
+  return numberFormatsWithCustomPattern.includes(value);
+}

--- a/src/i18n-l10n-editor/placeholders/placeholder.ts
+++ b/src/i18n-l10n-editor/placeholders/placeholder.ts
@@ -1,0 +1,39 @@
+import { PlaceholderType } from './placeholderType';
+
+export class Placeholder {
+  public format?: string;
+
+  public symbol?: string;
+
+  public decimalDigits?: number;
+
+  public customPattern?: string;
+
+  constructor(
+    readonly name: string,
+    readonly value: string,
+    readonly type: PlaceholderType
+  ) {
+    // do nothing.
+  }
+
+  addFormat(value: string): this {
+    this.format = value;
+    return this;
+  }
+
+  addSymbol(value: string): this {
+    this.symbol = value;
+    return this;
+  }
+
+  addDecimalDigits(value: number): this {
+    this.decimalDigits = value;
+    return this;
+  }
+
+  addCustomPattern(format: string): this {
+    this.customPattern = format;
+    return this;
+  }
+}

--- a/src/i18n-l10n-editor/placeholders/placeholderQuickPick.ts
+++ b/src/i18n-l10n-editor/placeholders/placeholderQuickPick.ts
@@ -1,0 +1,17 @@
+import {
+  PlaceholderType,
+  PlaceholderTypeItem,
+  getPlaceholderType,
+  getPlaceholderTypes
+} from './placeholderType';
+import { showQuickPick } from '../quickPick/showQuickPick';
+
+export async function showPlaceholderQuickPick(
+  variable: string
+): Promise<PlaceholderType> {
+  const placeholderTypeValue = await showQuickPick(
+    `Choose the type for the variable ${variable}`,
+    getPlaceholderTypes().map((p) => new PlaceholderTypeItem(p))
+  );
+  return getPlaceholderType(placeholderTypeValue);
+}

--- a/src/i18n-l10n-editor/placeholders/placeholderType.ts
+++ b/src/i18n-l10n-editor/placeholders/placeholderType.ts
@@ -1,0 +1,26 @@
+import { QuickPickItem } from 'vscode';
+
+export enum PlaceholderType {
+  String = 'String',
+  int = 'int',
+  num = 'num',
+  double = 'double',
+  DateTime = 'DateTime',
+  plural = 'plural'
+}
+
+export function getPlaceholderTypes() {
+  return Object.keys(PlaceholderType).filter((p) => isNaN(Number(p)));
+}
+
+export function getPlaceholderType(placeholderTypeValue: string) {
+  return Object.values(PlaceholderType).filter(
+    (p) => p.toString() === placeholderTypeValue
+  )[0] as PlaceholderType;
+}
+
+export class PlaceholderTypeItem implements QuickPickItem {
+  constructor(readonly label: string) {
+    // do nothing.
+  }
+}

--- a/src/i18n-l10n-editor/providers/localizationActionProvider.ts
+++ b/src/i18n-l10n-editor/providers/localizationActionProvider.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+import { CommandParameters } from '../commands/commandParameters';
+import { InputBoxCommand } from '../commands/inputBoxCommand';
+import { empty } from '../shared/constants';
+import { getUnescapedString } from '../shared/parser/parser';
+
+export class LocalizationActionProvider implements vscode.CodeActionProvider {
+  public static readonly providedCodeActionKinds = [
+    vscode.CodeActionKind.QuickFix
+  ];
+
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range
+  ): vscode.ProviderResult<vscode.CodeAction[]> {
+    const text = getUnescapedString(document.getText(range));
+    if (text === empty) {
+      return;
+    }
+
+    return [
+      this.createRefactorExtractToL10nFiles(
+        new CommandParameters(document.uri, range, text)
+      )
+    ];
+  }
+
+  private createRefactorExtractToL10nFiles(
+    commandParameters: CommandParameters
+  ): vscode.CodeAction {
+    const codeAction = new vscode.CodeAction(
+      `Add text to i18n/l10n Editor`,
+      vscode.CodeActionKind.RefactorExtract
+    );
+    codeAction.command = new InputBoxCommand([commandParameters]);
+    return codeAction;
+  }
+}

--- a/src/i18n-l10n-editor/quickPick/showQuickPick.ts
+++ b/src/i18n-l10n-editor/quickPick/showQuickPick.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+
+export class LionizationPickItem implements vscode.QuickPickItem {
+  constructor(readonly label: string) {
+    // do nothing.
+  }
+}
+
+export async function showQuickPick(
+  title: string,
+  items: LionizationPickItem[]
+): Promise<string> {
+  const disposables: vscode.Disposable[] = [];
+  try {
+    return await new Promise<string>((resolve) => {
+      const quickPick = vscode.window.createQuickPick();
+      quickPick.title = title;
+      quickPick.items = items;
+      disposables.push(
+        quickPick.onDidChangeSelection((selected) => {
+          quickPick.enabled = false;
+          quickPick.busy = true;
+          const item = selected[0];
+          resolve(item.label);
+          quickPick.enabled = true;
+          quickPick.busy = false;
+          quickPick.hide();
+        })
+      );
+      quickPick.show();
+    });
+  } finally {
+    disposables.forEach((d) => {
+      d.dispose();
+    });
+  }
+}

--- a/src/i18n-l10n-editor/services/ije-data-render-service.ts
+++ b/src/i18n-l10n-editor/services/ije-data-render-service.ts
@@ -47,8 +47,8 @@ export class IJEDataRenderService {
         return render;
     }
 
-    private static _getTableHeader(column: string, position, sort: IJESort) {
-        let style = position >= 0 ? `position: sticky; left: ${position}px; z-index: 1000;` : '';
+    private static _getTableHeader(column: string, position, width, sort: IJESort) {
+        let style = position >= 0 ? `position: sticky; left: ${position}px; z-index: 1000; width: ${width}px; maxWidth: ${width}px; background: #1f1f1f;` : width >= 0 ? 'width: ${width}px; maxWidth: ${width}px; background: #1f1f1f;' : '';
         return `<th class="text-center" style="background: #1f1f1f; cursor: pointer; ${style}" onclick="sort('${column}',${sort.column === column ? !sort.ascending : true})">
            ${column}             
            ${sort.column === column ? (sort.ascending ? '<i class="icon-up-open"></i>' : '<i class="icon-down-open"></i>') : ''}
@@ -59,12 +59,12 @@ export class IJEDataRenderService {
     static renderTable(translations: IJEDataTranslation[], languages: string[], page: IJEPage, sort: IJESort, showFolder: boolean = true, hasTranslateService = false) {
         let render = '<table class="table table-borderless" style="margin-left: -10px; margin-top: 80px;" >';
         render += '<tr>';
-        render += '<th style="background: #1f1f1f; position: sticky; left: 0px; z-index: 1000; width: 100px; maxWidth: 100px; margin: 0px; padding: 0px;"> </th>';
+        render += '<th style="background: #1f1f1f; position: sticky; left: 0px; z-index: 1000; width: 40px; maxWidth: 30px; margin: 0px; padding: 0px;"> </th>';
         const folders = IJEConfiguration.WORKSPACE_FOLDERS;
         if (showFolder && folders.length > 1) {
-            render += this._getTableHeader('FOLDER', -1, sort);
+            render += this._getTableHeader('FOLDER', -1, 300, sort);
         }
-        render += this._getTableHeader('KEY', 100, sort);
+        render += this._getTableHeader('KEY', 40, 418, sort);
 
         let _defaultARB = 'app_en';
         folders.forEach(d => {
@@ -87,9 +87,9 @@ export class IJEDataRenderService {
 
         languages.forEach((language: string) => {
             if (language === _defaultARB) {
-                render += `${this._getTableHeader(language, 425, sort)}`;
+                render += `${this._getTableHeader(language, 490, 430, sort)}`;
             } else {
-                render += `${this._getTableHeader(language, -1, sort)}`;
+                render += `${this._getTableHeader(language, -1, 430, sort)}`;
             }
         });
         render += '</tr>';
@@ -97,8 +97,8 @@ export class IJEDataRenderService {
         translations.forEach(t => {
             render += '<tr style="padding: 0px; margin: 0px; left: 0px">';
             render +=
-                `<td style="background: #1f1f1f; width: 100px; maxWidth: 100px; white-space: nowrap; position: sticky; left: 0px; z-index: 1000; margin: 0px; padding: 0px;">` +
-                `<button type="button" class="btn" style="width: 100px; maxWidth: 100px;" onclick="remove(${t.id})"><i class="error-vscode icon-trash-empty"></i></button></td>`;
+                `<td style="background: #1f1f1f; width: 40px; maxWidth: 40px; white-space: nowrap; position: sticky; left: 0px; z-index: 1000; margin: 0px; padding: 0px;">` +
+                `<button type="button" class="btn" style="width: 40px; maxWidth: 40px; padding-top: 20px;" onclick="remove(${t.id})"><i class="error-vscode icon-trash-empty"></i></button></td>`;
 
             if (showFolder && folders.length > 1) {
                 render += `<td style="background: #1f1f1f; width: 300px;"><select id="select-folder-${t.id}" class="form-control" style="width: 300px;" onchange="updateFolder(this,${t.id})">`;
@@ -110,30 +110,34 @@ export class IJEDataRenderService {
                 render += ' </select></td>';
             }
 
-            let indent = 10;
-            let width = 301;
+            let indent = 0;
+            let width = 418;
             if (sort.column === 'KEY' && !t.key.startsWith('@@') && t.key.startsWith('@')) {
                 let i = t.key.length - t.key.replace(/\./g, '').length;
                 for (let j = 0; j < i; ++j) {
+                    if (indent === 0 ) {
+                        indent += 10;
+                    }
                     indent += 10;
                     width -= 10;
                 }
             }
 
-            render += `<td style="background: #1f1f1f; white-space: nowrap; position: sticky; left: 100px; z-index: 1000;">
-                    <input id="input-key-${t.id}" class="form-control ${
-                t.valid ? '' : 'is-invalid'
-            }" style="width: ${width}px; margin-left: ${indent}px" type="text" placeholder="Key..." value="${t.key.replace(/"/g, '&quot;')}" onfocus="mark(${
-                t.id
-            })" onchange="updateInput(this,${t.id});" />
-                    <div id="input-key-${t.id}-feedback" class="invalid-feedback error-vscode">${t.error}</div>
-                </td>
+            render +=
+                `<td style="background: #1f1f1f; white-space: nowrap; position: sticky; left: 40px; z-index: 1000; maxWidth: ${width}px;">` +
+                `<input id="input-key-${t.id}" class="form-control ${
+                    t.valid ? '' : 'is-invalid'
+                }" style="width: ${width}px; maxWidth: ${width}px;  margin-left: ${indent}px" type="text" placeholder="Key..." value="${t.key.replace(/"/g, '&quot;')}" onfocus="mark(${
+                    t.id
+                })" onchange="updateInput(this,${t.id});" />` +
+                `<div id="input-key-${t.id}-feedback" class="invalid-feedback error-vscode">${t.error}</div>` +
+                `</td>
             `;
 
             languages.forEach((language: string) => {
-                render += `<td style="background: #1f1f1f; ${language === _defaultARB ? `position: sticky; left: 425px; z-index: 1000;` : ''}">`;
+                render += `<td style="background: #1f1f1f; ${language === _defaultARB ? `position: sticky; left: 490px; z-index: 1000; maxWidth: 430px; width: 430px;` : ' maxWidth: 430px; width: 430px;'}">`;
                 if (hasTranslateService) {
-                    render += `<div class="input-group" style="minWith: 330px; width: 330px; white-space: nowrap;">`;
+                    render += `<div class="input-group" style="minWith: 430px; width: 430px; white-space: nowrap;">`;
                 }
                 render += `<input class="form-control" style="minWith: 270px; width: 270px; white-space: nowrap;" type="text" placeholder="Translation..." onfocus="mark(${t.id})" onchange="updateInput(this,${t.id},'${language}');" `;
                 if (t.languages[language]) {

--- a/src/i18n-l10n-editor/shared/constants.ts
+++ b/src/i18n-l10n-editor/shared/constants.ts
@@ -1,8 +1,8 @@
-export const extensionIdentifier = 'lsaudon.l10nization';
+export const extensionIdentifier = 'dion-chapman.i18n-l10n-editor';
 
 export const empty = '';
 
-export const parentSection = 'l10nization';
+export const parentSection = 'i18n-l10n-editor';
 
 export const appLocalizationsVariableSection = 'appLocalizationsVariable';
 export const defaultVariable = 'l10n';

--- a/src/i18n-l10n-editor/shared/keyValuePair.ts
+++ b/src/i18n-l10n-editor/shared/keyValuePair.ts
@@ -1,0 +1,8 @@
+export class KeyValuePair {
+  constructor(
+    readonly key: string,
+    readonly value: string
+  ) {
+    // do nothing.
+  }
+}

--- a/src/i18n-l10n-editor/shared/nochange.ts
+++ b/src/i18n-l10n-editor/shared/nochange.ts
@@ -1,0 +1,11 @@
+import { empty } from './constants';
+
+export const nochange = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036F]/u, empty)
+    .split(/[^a-zA-Z0-9]/u)
+    .map((element) =>
+      element
+    )
+    .join(empty);


### PR DESCRIPTION
- Added the ability to select text (must include quotes) in .dart file to add to translations
  - You will need to open the i18n/l10n Editor first and then click on the tab after you add the text
  - Use the context globe to select 'Add text to i18n/l10n Editor'
  - It will auto translate of enabled and follows the case style setting